### PR TITLE
Automatic reconnection fix

### DIFF
--- a/profilematicd/src/logic/presence/actionpresenceimpl.h
+++ b/profilematicd/src/logic/presence/actionpresenceimpl.h
@@ -36,6 +36,8 @@ public:
 
     void activate(const Rule &rule);
 private slots:
+    void onConnectsAutomaticallyChangeFinished(Tp::PendingOperation *op);
+    void onAutomaticPresenceChangeFinished(Tp::PendingOperation *op);
     void onPresenceChangeFinished(Tp::PendingOperation *op);
     void onAccountManagerReady(Tp::PendingOperation *op);
 private:


### PR DESCRIPTION
This commit should fix the issue reported on the forum regarding the reconnection of accounts even if they were forced to offline mode.

 Telepathy's "connects automatically" property is used to determine if an account should be set to the presence specified by "automatic presence" if the account is supposed to be used by an application or if a connection to the internet was detected. 

I assume that the previous implementation ended up in a race condition with the automatic presence change and the accounts ended up staying online.

I have based this commit on the current devel branch (I also did this for the last pull request) but let me know if you're having troubles merging this so we can figure out what is causing this.
